### PR TITLE
prevent warning to be thrown in log by giving log level

### DIFF
--- a/app/code/community/Mpchadwick/PageCacheHitRate/Model/SystemLog.php
+++ b/app/code/community/Mpchadwick/PageCacheHitRate/Model/SystemLog.php
@@ -2,7 +2,7 @@
 
 class Mpchadwick_PageCacheHitRate_Model_SystemLog
 {
-    public function log($message, $level)
+    public function log($message, $level = null)
     {
         Mage::log($message, $level, $this->logFile(), true);
     }

--- a/app/code/community/Mpchadwick/PageCacheHitRate/Model/Tracker/NewRelic.php
+++ b/app/code/community/Mpchadwick/PageCacheHitRate/Model/Tracker/NewRelic.php
@@ -8,7 +8,7 @@ class Mpchadwick_PageCacheHitRate_Model_Tracker_NewRelic
     {
         if (!function_exists('newrelic_record_custom_event')) {
             $msg = 'You are using the New Relic tracker, but don\'t have the agent set up properly';
-            $this->logger->log($msg);
+            $this->logger->log($msg, null);
             return;
         }
 

--- a/app/code/community/Mpchadwick/PageCacheHitRate/Model/Tracker/NewRelic.php
+++ b/app/code/community/Mpchadwick/PageCacheHitRate/Model/Tracker/NewRelic.php
@@ -8,7 +8,7 @@ class Mpchadwick_PageCacheHitRate_Model_Tracker_NewRelic
     {
         if (!function_exists('newrelic_record_custom_event')) {
             $msg = 'You are using the New Relic tracker, but don\'t have the agent set up properly';
-            $this->logger->log($msg, null);
+            $this->logger->log($msg);
             return;
         }
 


### PR DESCRIPTION
When NewRelic is not well configured, or not available. For example on a dev environment. This should be logged. Right now it throws a warning when trying to log. This PR adds a log level of `null` to fix the issue.