### PR TITLE
Ignore requests that are not eligible for FPC

### DIFF
--- a/app/code/community/Mpchadwick/PageCacheHitRate/Model/Observer.php
+++ b/app/code/community/Mpchadwick/PageCacheHitRate/Model/Observer.php
@@ -25,6 +25,7 @@ class Mpchadwick_PageCacheHitRate_Model_Observer
         $params = $paramProvider->baseParams(true) + array(
             'type' => $type,
             'route' => $this->trackerRoute(),
+            'cacheable' => $this->isRequestCacheable()
         );
 
         $factory = Mage::getModel('mpchadwick_pagecachehitrate/trackerFactory');
@@ -38,6 +39,20 @@ class Mpchadwick_PageCacheHitRate_Model_Observer
                 $tracker->trackContainerMisses($params, $alias);
             }
         }
+    }
+
+    /**
+     * Determine this request is cacheable in FPC
+     *
+     * @return bool
+     */
+    protected function isRequestCacheable()
+    {
+        $request = Mage::app()->getRequest();
+        $processor = Mage::getSingleton('enterprise_pagecache/processor');
+        $subprocessor = $processor->getMetadata('cache_subprocessor');
+
+        return $subprocessor !== null && $processor->canProcessRequest($request);
     }
 
     /**


### PR DESCRIPTION
Hi Max,

Thanks for your great extension and very informative talk on NomadMage on the subject.

I've noticed something though while testing the module. *All* requests contribute to the hit/miss/partial rate, for instance also the cart page. In some way, I believe that skews the results. Magento out-of-the-box only supports FPC for certain "subprocessors" and the cart page will *never* be cached, so it's always going to add to the miss total. I'm mostly interested in having the stats on how the FPC is working for pages that *should* be cached, not the ones that I know will never be cached.

The change in this PR filters out any requests (routes) that would never be cached.

Cheers,
Steve